### PR TITLE
feat: async execute, sequentially

### DIFF
--- a/__tests__/exexutors/chain.executor.spec.ts
+++ b/__tests__/exexutors/chain.executor.spec.ts
@@ -73,4 +73,32 @@ describe('ChainExecutor', () => {
       .execute(mockOnError)
     expect(mockOnError).toHaveBeenCalled()
   })
+
+  it('chain execute: promise execute', async () => {
+    const chain = new ChainExecutor({ value: 1 })
+    const result = await chain
+      .stream(
+        (it) => {
+          it.value += 10
+          return Promise.resolve(it.value.toString())
+        },
+        async (it) => {
+          const value = await it
+          const isString = typeof value === 'string' ? true : false
+          return Promise.resolve(isString)
+        },
+        async (it) => {
+          const value = await it
+          return !value ? 'end' : undefined
+        },
+        async (it) => {
+          const value = await it
+          const isString = typeof value === 'string' ? true : false
+          return Promise.resolve(isString)
+        }
+      )
+      .asAsync()
+      .execute()
+    expect(result).toBeUndefined()
+  })
 })

--- a/lib/executors/chain.executor.d.ts
+++ b/lib/executors/chain.executor.d.ts
@@ -1,9 +1,13 @@
 import { BaseExecutor } from './__interfaces__';
-import { Action } from '../types';
+import { Action, PromiseOr } from '../types';
 export declare class ChainExecutor<T> implements BaseExecutor {
     private _initialValue;
     private _actions;
+    private _isPromiseContained;
     constructor(initialValue: T);
-    stream<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<A, B>, act3?: Action<B, C>, act4?: Action<C, D>, act5?: Action<D, E>, act6?: Action<E, F>, act7?: Action<F, G>, act8?: Action<G, H>, act9?: Action<H, I>, act10?: Action<I, J>): this;
-    execute(onError?: (error: any) => any): T;
+    stream<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<A, B>, act3?: Action<B, C>, act4?: Action<C, D>, act5?: Action<D, E>, act6?: Action<E, F>, act7?: Action<F, G>, act8?: Action<G, H>, act9?: Action<H, I>, act10?: Action<I, J>): Pick<this, Exclude<keyof this, "stream">>;
+    asAsync(): Pick<this, "execute">;
+    execute(onError?: (error: any) => any): PromiseOr<any>;
+    private _execute;
+    private _promiseExecute;
 }

--- a/lib/executors/chain.executor.js
+++ b/lib/executors/chain.executor.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 class ChainExecutor {
     constructor(initialValue) {
         this._actions = [];
+        this._isPromiseContained = false;
         this._initialValue = initialValue;
     }
     stream(act1, act2, act3, act4, act5, act6, act7, act8, act9, act10) {
@@ -21,17 +22,16 @@ class ChainExecutor {
         this._actions = _actions;
         return this;
     }
+    asAsync() {
+        this._isPromiseContained = true;
+        return this;
+    }
     execute(onError) {
         let result = this._initialValue;
         try {
-            this._actions.reduce((pre, curr) => {
-                if (typeof pre === 'undefined') {
-                    return;
-                }
-                const _result = curr(pre);
-                result = _result;
-                return _result;
-            }, this._initialValue);
+            result = this._isPromiseContained
+                ? this._promiseExecute()
+                : this._execute();
         }
         catch (e) {
             if (onError) {
@@ -41,6 +41,30 @@ class ChainExecutor {
                 console.error(e);
             }
         }
+        return result;
+    }
+    _execute() {
+        let result = this._initialValue;
+        this._actions.reduce((pre, curr) => {
+            if (typeof pre === 'undefined') {
+                return;
+            }
+            const _result = curr(pre);
+            result = _result;
+            return _result;
+        }, this._initialValue);
+        return result;
+    }
+    async _promiseExecute() {
+        let result = this._initialValue;
+        await this._actions.reduce(async (pre, curr) => {
+            if (pre instanceof Promise && typeof (await pre) === 'undefined') {
+                return;
+            }
+            const _result = await curr(pre);
+            result = _result;
+            return _result;
+        }, Promise.resolve(this._initialValue));
         return result;
     }
 }

--- a/lib/executors/executor.facade.d.ts
+++ b/lib/executors/executor.facade.d.ts
@@ -4,7 +4,37 @@ import { BatchExecutor } from './batch.executor';
 export declare class StreamExecutorFacade<T> {
     private _initialValue;
     constructor(initialValue: T);
-    chain<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<A, B>, act3?: Action<B, C>, act4?: Action<C, D>, act5?: Action<D, E>, act6?: Action<E, F>, act7?: Action<F, G>, act8?: Action<G, H>, act9?: Action<H, I>, act10?: Action<I, J>): Pick<ChainExecutor<T>, "execute">;
+    /**
+     * sequential execute.
+     * call `asAsync` method after chain method if you use async/await in chain.
+     * @see https://github.com/nor-ko-hi-jp/stream-executor/blob/master/README.md#4-use-asynchronous-execution-in-createstreamchain
+     * @see https://github.com/nor-ko-hi-jp/stream-executor/blob/master/README.md#using-stream-executor
+     * @param act1 (value: T) => U
+     * @param act2 (value: T) => U
+     * @param act3 (value: T) => U
+     * @param act4 (value: T) => U
+     * @param act5 (value: T) => U
+     * @param act6 (value: T) => U
+     * @param act7 (value: T) => U
+     * @param act8 (value: T) => U
+     * @param act9 (value: T) => U
+     * @param act10 (value: T) => U
+     */
+    chain<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<A, B>, act3?: Action<B, C>, act4?: Action<C, D>, act5?: Action<D, E>, act6?: Action<E, F>, act7?: Action<F, G>, act8?: Action<G, H>, act9?: Action<H, I>, act10?: Action<I, J>): Pick<Pick<ChainExecutor<T>, "execute" | "asAsync">, "execute" | "asAsync">;
+    /**
+     * batch execute, like `when` in Kotlin.
+     * @see https://github.com/nor-ko-hi-jp/stream-executor/blob/master/README.md#using-stream-executor-1
+     * @param act1 (value: T) => U
+     * @param act2 (value: T) => U
+     * @param act3 (value: T) => U
+     * @param act4 (value: T) => U
+     * @param act5 (value: T) => U
+     * @param act6 (value: T) => U
+     * @param act7 (value: T) => U
+     * @param act8 (value: T) => U
+     * @param act9 (value: T) => U
+     * @param act10 (value: T) => U
+     */
     batch<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<T, B>, act3?: Action<T, C>, act4?: Action<T, D>, act5?: Action<T, E>, act6?: Action<T, F>, act7?: Action<T, G>, act8?: Action<T, H>, act9?: Action<T, I>, act10?: Action<T, J>): Pick<BatchExecutor<T>, "execute">;
 }
 /**

--- a/lib/executors/executor.facade.js
+++ b/lib/executors/executor.facade.js
@@ -6,10 +6,40 @@ class StreamExecutorFacade {
     constructor(initialValue) {
         this._initialValue = initialValue;
     }
+    /**
+     * sequential execute.
+     * call `asAsync` method after chain method if you use async/await in chain.
+     * @see https://github.com/nor-ko-hi-jp/stream-executor/blob/master/README.md#4-use-asynchronous-execution-in-createstreamchain
+     * @see https://github.com/nor-ko-hi-jp/stream-executor/blob/master/README.md#using-stream-executor
+     * @param act1 (value: T) => U
+     * @param act2 (value: T) => U
+     * @param act3 (value: T) => U
+     * @param act4 (value: T) => U
+     * @param act5 (value: T) => U
+     * @param act6 (value: T) => U
+     * @param act7 (value: T) => U
+     * @param act8 (value: T) => U
+     * @param act9 (value: T) => U
+     * @param act10 (value: T) => U
+     */
     chain(act1, act2, act3, act4, act5, act6, act7, act8, act9, act10) {
         const executor = new chain_executor_1.ChainExecutor(this._initialValue).stream(act1, act2, act3, act4, act5, act6, act7, act8, act9, act10);
         return executor;
     }
+    /**
+     * batch execute, like `when` in Kotlin.
+     * @see https://github.com/nor-ko-hi-jp/stream-executor/blob/master/README.md#using-stream-executor-1
+     * @param act1 (value: T) => U
+     * @param act2 (value: T) => U
+     * @param act3 (value: T) => U
+     * @param act4 (value: T) => U
+     * @param act5 (value: T) => U
+     * @param act6 (value: T) => U
+     * @param act7 (value: T) => U
+     * @param act8 (value: T) => U
+     * @param act9 (value: T) => U
+     * @param act10 (value: T) => U
+     */
     batch(act1, act2, act3, act4, act5, act6, act7, act8, act9, act10) {
         const executor = new batch_executor_1.BatchExecutor(this._initialValue).stream(act1, act2, act3, act4, act5, act6, act7, act8, act9, act10);
         return executor;

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -4,6 +4,7 @@ declare type PickKeysByType<T, V> = {
 declare type ArrayOr<T, U> = T extends Array<any> ? T : U;
 declare type OrMapObject<T, U> = T extends Record<string, unknown> ? U : T;
 declare type PickFunctionKeys<T> = PickKeysByType<T, Function>;
+export declare type PromiseOr<T> = T extends Promise<T> ? Promise<T> : T;
 export declare type OmitFunction<T> = ArrayOr<T, OrMapObject<T, Omit<T, PickFunctionKeys<T>>>>;
 export declare type Action<T, U> = (value: T) => U;
 export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-executor",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-executor",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-executor",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "functional stream programming",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-executor",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "functional stream programming",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/executors/chain.executor.ts
+++ b/src/executors/chain.executor.ts
@@ -1,9 +1,10 @@
 import { BaseExecutor } from './__interfaces__'
-import { Action } from '../types'
+import { Action, PromiseOr } from '../types'
 
 export class ChainExecutor<T> implements BaseExecutor {
   private _initialValue: T
-  private _actions: Action<any, any>[] = []
+  private _actions: Action<PromiseOr<any>, PromiseOr<any>>[] = []
+  private _isPromiseContained = false
 
   constructor(initialValue: T) {
     this._initialValue = initialValue
@@ -32,22 +33,25 @@ export class ChainExecutor<T> implements BaseExecutor {
       act8,
       act9,
       act10,
-    ].filter((act) => typeof act !== 'undefined') as Action<any, any>[]
+    ].filter((act) => typeof act !== 'undefined') as Action<
+      PromiseOr<any>,
+      PromiseOr<any>
+    >[]
     this._actions = _actions
-    return this
+    return this as Omit<this, 'stream'>
   }
 
-  execute(onError?: (error: any) => any) {
-    let result = this._initialValue
+  asAsync() {
+    this._isPromiseContained = true
+    return this as Pick<this, 'execute'>
+  }
+
+  execute(onError?: (error: any) => any): PromiseOr<any> {
+    let result: PromiseOr<any> = this._initialValue
     try {
-      this._actions.reduce((pre, curr) => {
-        if (typeof pre === 'undefined') {
-          return
-        }
-        const _result = curr(pre)
-        result = _result
-        return _result
-      }, this._initialValue)
+      result = this._isPromiseContained
+        ? this._promiseExecute()
+        : this._execute()
     } catch (e) {
       if (onError) {
         onError(e)
@@ -55,6 +59,37 @@ export class ChainExecutor<T> implements BaseExecutor {
         console.error(e)
       }
     }
+
+    return result
+  }
+
+  private _execute(): any {
+    let result = this._initialValue
+    this._actions.reduce((pre, curr) => {
+      if (typeof pre === 'undefined') {
+        return
+      }
+      const _result = curr(pre)
+      result = _result
+      return _result
+    }, this._initialValue)
+    return result
+  }
+
+  private async _promiseExecute(): Promise<any> {
+    let result = this._initialValue
+    await this._actions.reduce(
+      async (pre, curr: Action<PromiseOr<any>, PromiseOr<any>>) => {
+        if (pre instanceof Promise && typeof (await pre) === 'undefined') {
+          return
+        }
+
+        const _result = await curr(pre)
+        result = _result
+        return _result
+      },
+      Promise.resolve(this._initialValue)
+    )
 
     return result
   }

--- a/src/executors/executor.facade.ts
+++ b/src/executors/executor.facade.ts
@@ -1,4 +1,4 @@
-import { Action } from '../types'
+import { Action, PromiseOr } from '../types'
 import { ChainExecutor } from './chain.executor'
 import { BatchExecutor } from './batch.executor'
 
@@ -22,19 +22,19 @@ export class StreamExecutorFacade<T> {
     act10?: Action<I, J>
   ) {
     const executor = new ChainExecutor(this._initialValue).stream(
-      act1,
-      act2,
-      act3,
-      act4,
-      act5,
-      act6,
-      act7,
-      act8,
-      act9,
-      act10
+      act1 as Action<PromiseOr<any>, PromiseOr<any>>,
+      act2 as Action<PromiseOr<any>, PromiseOr<any>>,
+      act3 as Action<PromiseOr<any>, PromiseOr<any>>,
+      act4 as Action<PromiseOr<any>, PromiseOr<any>>,
+      act5 as Action<PromiseOr<any>, PromiseOr<any>>,
+      act6 as Action<PromiseOr<any>, PromiseOr<any>>,
+      act7 as Action<PromiseOr<any>, PromiseOr<any>>,
+      act8 as Action<PromiseOr<any>, PromiseOr<any>>,
+      act9 as Action<PromiseOr<any>, PromiseOr<any>>,
+      act10 as Action<PromiseOr<any>, PromiseOr<any>>
     )
 
-    return executor as Pick<typeof executor, 'execute'>
+    return executor as Omit<typeof executor, 'stream'>
   }
 
   batch<A, B, C, D, E, F, G, H, I, J>(

--- a/src/executors/executor.facade.ts
+++ b/src/executors/executor.facade.ts
@@ -9,6 +9,22 @@ export class StreamExecutorFacade<T> {
     this._initialValue = initialValue
   }
 
+  /**
+   * sequential execute.
+   * call `asAsync` method after chain method if you use async/await in chain.
+   * @see https://github.com/nor-ko-hi-jp/stream-executor/blob/master/README.md#4-use-asynchronous-execution-in-createstreamchain
+   * @see https://github.com/nor-ko-hi-jp/stream-executor/blob/master/README.md#using-stream-executor
+   * @param act1 (value: T) => U
+   * @param act2 (value: T) => U
+   * @param act3 (value: T) => U
+   * @param act4 (value: T) => U
+   * @param act5 (value: T) => U
+   * @param act6 (value: T) => U
+   * @param act7 (value: T) => U
+   * @param act8 (value: T) => U
+   * @param act9 (value: T) => U
+   * @param act10 (value: T) => U
+   */
   chain<A, B, C, D, E, F, G, H, I, J>(
     act1: Action<T, A>,
     act2?: Action<A, B>,
@@ -37,6 +53,20 @@ export class StreamExecutorFacade<T> {
     return executor as Omit<typeof executor, 'stream'>
   }
 
+  /**
+   * batch execute, like `when` in Kotlin.
+   * @see https://github.com/nor-ko-hi-jp/stream-executor/blob/master/README.md#using-stream-executor-1
+   * @param act1 (value: T) => U
+   * @param act2 (value: T) => U
+   * @param act3 (value: T) => U
+   * @param act4 (value: T) => U
+   * @param act5 (value: T) => U
+   * @param act6 (value: T) => U
+   * @param act7 (value: T) => U
+   * @param act8 (value: T) => U
+   * @param act9 (value: T) => U
+   * @param act10 (value: T) => U
+   */
   batch<A, B, C, D, E, F, G, H, I, J>(
     act1: Action<T, A>,
     act2?: Action<T, B>,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,8 @@ type ArrayOr<T, U> = T extends Array<any> ? T : U
 type OrMapObject<T, U> = T extends Record<string, unknown> ? U : T
 type PickFunctionKeys<T> = PickKeysByType<T, Function>
 
+export type PromiseOr<T> = T extends Promise<T> ? Promise<T> : T
+
 export type OmitFunction<T> = ArrayOr<
   T,
   OrMapObject<T, Omit<T, PickFunctionKeys<T>>>


### PR DESCRIPTION
# Usage 
  ```ts
  import { createStream, tap, map } from 'stream-executor'
  const result = await createStream(1)
    .chain(
      tap((it) => console.log(it)),             // 1
      map(async (it) => await callAPI(it)),    
      map(async (it) => parseToModel(await it)) // Record<string, any>
    )
    .asAsync()
    .execute()
  console.log(result) // Record<string, any>
  ``` 