### PR TITLE
refactor:[BaseExecutor] add initialValue property

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,11 @@ console.log(isLoading)    // false
 
 ## 6. Replace `chain` or `batch` executor
   - Set `option.chainClass` or `option.batchClass` if you would change execution process, please
+  - These Classes are initialized with initialValue as an argument
   ```ts
   import { BaseExecutor, createStream } from 'stream-executor'
   class MockChainExecutor implements BaseExecutor {
+    constructor(public initialValue: any) {}
     stream(...args: any[]) {
       return this
     }
@@ -219,6 +221,7 @@ console.log(isLoading)    // false
   }
 
   class MockBatchExecutor implements BaseExecutor {
+    constructor(public initialValue: any) {}
     stream(...args: any[]) {
       return this
     }

--- a/__tests__/exexutors/batch.executor.spec.ts
+++ b/__tests__/exexutors/batch.executor.spec.ts
@@ -1,11 +1,11 @@
 import { BatchExecutor } from '../../src/executors/batch.executor'
 
-describe('ParallelExecutor', () => {
+describe('BatchExecutor', () => {
   afterEach(() => {
     jest.clearAllMocks()
   })
 
-  it('parallel execute: succeeded', () => {
+  it('batch execute: succeeded', () => {
     const parallel = new BatchExecutor('apple')
     let favoriteFruit = ''
     const fruitNames: string[] = []
@@ -25,7 +25,7 @@ describe('ParallelExecutor', () => {
     expect(fruitNames[0]).toEqual('apple')
   })
 
-  it('parallel execute: failured, default errorHandling', () => {
+  it('batch execute: failured, default errorHandling', () => {
     const spyConsole = jest.spyOn(console, 'error')
     const parallel = new BatchExecutor('apple')
     let favoriteFruit = ''
@@ -48,7 +48,7 @@ describe('ParallelExecutor', () => {
     expect(spyConsole).toHaveBeenCalled()
   })
 
-  it('parallel execute: failured, custom errorHandling', () => {
+  it('batch execute: failured, custom errorHandling', () => {
     const parallel = new BatchExecutor('apple')
     let favoriteFruit = ''
     const fruitNames: string[] = []
@@ -69,5 +69,10 @@ describe('ParallelExecutor', () => {
 
     expect(favoriteFruit).toEqual('apple')
     expect(mockOnError).toHaveBeenCalled()
+  })
+
+  it('batch execute: initialValue is correct', () => {
+    const batch = new BatchExecutor('apple')
+    expect(batch.initialValue).toEqual('apple')
   })
 })

--- a/__tests__/exexutors/chain.executor.spec.ts
+++ b/__tests__/exexutors/chain.executor.spec.ts
@@ -101,4 +101,10 @@ describe('ChainExecutor', () => {
       .execute()
     expect(result).toBeUndefined()
   })
+
+  it('chain execute: initialValue is correct', () => {
+    const chain = new ChainExecutor(1)
+
+    expect(chain.initialValue).toEqual(1)
+  })
 })

--- a/__tests__/exexutors/executor.facade.spec.ts
+++ b/__tests__/exexutors/executor.facade.spec.ts
@@ -65,6 +65,7 @@ describe('StreamExecutorFacade', () => {
   it('replace Chain and Batch Executor', () => {
     const spyConsole = jest.spyOn(console, 'log')
     class MockChainExecutor implements BaseExecutor {
+      constructor(public initialValue: any) {}
       stream(...args: any[]) {
         return this
       }
@@ -74,6 +75,7 @@ describe('StreamExecutorFacade', () => {
     }
 
     class MockBatchExecutor implements BaseExecutor {
+      constructor(public initialValue: any) {}
       stream(...args: any[]) {
         return this
       }

--- a/lib/executors/__interfaces__/base.executor.d.ts
+++ b/lib/executors/__interfaces__/base.executor.d.ts
@@ -1,4 +1,5 @@
 export interface BaseExecutor {
+    readonly initialValue: any;
     stream: (...args: any[]) => Omit<this, 'stream'>;
     execute: (...args: any[]) => any;
 }

--- a/lib/executors/batch.executor.d.ts
+++ b/lib/executors/batch.executor.d.ts
@@ -4,6 +4,7 @@ export declare class BatchExecutor<T> implements BaseExecutor {
     private _initialValue;
     private _actions;
     constructor(initialValue: T);
+    get initialValue(): T;
     stream<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<T, B>, act3?: Action<T, C>, act4?: Action<T, D>, act5?: Action<T, E>, act6?: Action<T, F>, act7?: Action<T, G>, act8?: Action<T, H>, act9?: Action<T, I>, act10?: Action<T, J>): Omit<this, 'stream'>;
     execute(onError?: (error: any) => any): void;
 }

--- a/lib/executors/batch.executor.js
+++ b/lib/executors/batch.executor.js
@@ -5,6 +5,9 @@ class BatchExecutor {
         this._actions = [];
         this._initialValue = initialValue;
     }
+    get initialValue() {
+        return this._initialValue;
+    }
     stream(act1, act2, act3, act4, act5, act6, act7, act8, act9, act10) {
         const _actions = [
             act1,

--- a/lib/executors/chain.executor.d.ts
+++ b/lib/executors/chain.executor.d.ts
@@ -5,6 +5,7 @@ export declare class ChainExecutor<T> implements BaseExecutor {
     private _actions;
     private _isPromiseContained;
     constructor(initialValue: T);
+    get initialValue(): T;
     stream<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<A, B>, act3?: Action<B, C>, act4?: Action<C, D>, act5?: Action<D, E>, act6?: Action<E, F>, act7?: Action<F, G>, act8?: Action<G, H>, act9?: Action<H, I>, act10?: Action<I, J>): Omit<this, 'stream'>;
     asAsync(): Pick<this, 'execute'>;
     execute(onError?: (error: any) => any): PromiseOr<any>;

--- a/lib/executors/chain.executor.js
+++ b/lib/executors/chain.executor.js
@@ -6,6 +6,9 @@ class ChainExecutor {
         this._isPromiseContained = false;
         this._initialValue = initialValue;
     }
+    get initialValue() {
+        return this._initialValue;
+    }
     stream(act1, act2, act3, act4, act5, act6, act7, act8, act9, act10) {
         const _actions = [
             act1,

--- a/lib/executors/executor.facade.d.ts
+++ b/lib/executors/executor.facade.d.ts
@@ -24,7 +24,7 @@ export declare class StreamExecutorFacade<T> {
      * @param act9 (value: T) => U
      * @param act10 (value: T) => U
      */
-    chain<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<A, B>, act3?: Action<B, C>, act4?: Action<C, D>, act5?: Action<D, E>, act6?: Action<E, F>, act7?: Action<F, G>, act8?: Action<G, H>, act9?: Action<H, I>, act10?: Action<I, J>): Pick<Pick<BaseExecutor, "execute">, "execute">;
+    chain<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<A, B>, act3?: Action<B, C>, act4?: Action<C, D>, act5?: Action<D, E>, act6?: Action<E, F>, act7?: Action<F, G>, act8?: Action<G, H>, act9?: Action<H, I>, act10?: Action<I, J>): Pick<Pick<BaseExecutor, "execute" | "initialValue">, "execute" | "initialValue">;
     /**
      * batch execute, like `when` in Kotlin.
      * @see https://github.com/nor-ko-hi-jp/stream-executor/blob/master/README.md#using-stream-executor-1
@@ -39,7 +39,7 @@ export declare class StreamExecutorFacade<T> {
      * @param act9 (value: T) => U
      * @param act10 (value: T) => U
      */
-    batch<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<T, B>, act3?: Action<T, C>, act4?: Action<T, D>, act5?: Action<T, E>, act6?: Action<T, F>, act7?: Action<T, G>, act8?: Action<T, H>, act9?: Action<T, I>, act10?: Action<T, J>): Pick<Pick<BaseExecutor, "execute">, "execute">;
+    batch<A, B, C, D, E, F, G, H, I, J>(act1: Action<T, A>, act2?: Action<T, B>, act3?: Action<T, C>, act4?: Action<T, D>, act5?: Action<T, E>, act6?: Action<T, F>, act7?: Action<T, G>, act8?: Action<T, H>, act9?: Action<T, I>, act10?: Action<T, J>): Pick<Pick<BaseExecutor, "execute" | "initialValue">, "execute">;
     private _create;
 }
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-executor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-executor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "functional stream programming",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/executors/__interfaces__/base.executor.ts
+++ b/src/executors/__interfaces__/base.executor.ts
@@ -1,4 +1,5 @@
 export interface BaseExecutor {
+  readonly initialValue: any
   stream: (...args: any[]) => Omit<this, 'stream'>
   execute: (...args: any[]) => any
 }

--- a/src/executors/batch.executor.ts
+++ b/src/executors/batch.executor.ts
@@ -8,6 +8,10 @@ export class BatchExecutor<T> implements BaseExecutor {
     this._initialValue = initialValue
   }
 
+  get initialValue(): T {
+    return this._initialValue
+  }
+
   stream<A, B, C, D, E, F, G, H, I, J>(
     act1: Action<T, A>,
     act2?: Action<T, B>,

--- a/src/executors/chain.executor.ts
+++ b/src/executors/chain.executor.ts
@@ -10,6 +10,10 @@ export class ChainExecutor<T> implements BaseExecutor {
     this._initialValue = initialValue
   }
 
+  get initialValue(): T {
+    return this._initialValue
+  }
+
   stream<A, B, C, D, E, F, G, H, I, J>(
     act1: Action<T, A>,
     act2?: Action<A, B>,


### PR DESCRIPTION
```ts
interface BaseExecutor {
  readonly initialValue: any        // <--- Add
  stream: (...args: any[]) => Omit<this, 'stream'>
  execute: (...args: any[]) => any
}
```

# WHY
- Because chain and batch class are  are initialized with initialValue as an argument which is first argument of `createStream`

# Important
- Add initialValue prop in custom class, like this
```ts
import { createStream } from 'stream-executor'
class MockChainExecutor implements BaseExecutor {
    constructor(public initialValue: number) {}   // <--- Add
    stream(...args: any[]) {
      return this
    }
    execute() {
      console.log(this.initialValue)
    }
  }


const mockChainExecutor: MockChainExecutor = createStream(
  1, { chainClass: MockChainExecutor }
).chain((it) => it)

console.log(mockChainExecutor.initialValue) // 1

```